### PR TITLE
Add Fluid's and Floe's website (currently hosted on GitHub Pages)

### DIFF
--- a/jenkins_jobs/website-floeproject.org.yml
+++ b/jenkins_jobs/website-floeproject.org.yml
@@ -1,0 +1,23 @@
+- job:
+    name: 'website-floeproject.org'
+    project-type: 'freestyle'
+    display-name: 'website-floeproject.org'
+    scm:
+        - git:
+            url: https://github.com/fluid-project/floeproject.org.git
+            skip-tag: true
+            branches:
+                - gh-pages
+    triggers:
+        - github
+    publishers:
+      - email:
+            recipients: idi-ops@lists.inclusivedesign.ca
+      - ssh:
+            site: 'a5242a87_floeproject.org'
+            source: '**'
+            target: '/srv/www/a5242a87'
+            fail-on-error: true
+            use-pty: true
+            timeout: 180000
+

--- a/jenkins_jobs/website-fluidproject.org.yml
+++ b/jenkins_jobs/website-fluidproject.org.yml
@@ -1,0 +1,23 @@
+- job:
+    name: 'website-fluidproject.org'
+    project-type: 'freestyle'
+    display-name: 'website-fluidproject.org'
+    scm:
+        - git:
+            url: https://github.com/fluid-project/fluidproject.org.git
+            skip-tag: true
+            branches:
+                - gh-pages
+    triggers:
+        - github
+    publishers:
+      - email:
+            recipients: idi-ops@lists.inclusivedesign.ca
+      - ssh:
+            site: '87218b57_fluidproject.org'
+            source: '**'
+            target: '/srv/www/87218b57'
+            fail-on-error: true
+            use-pty: true
+            timeout: 180000
+


### PR DESCRIPTION
I would like to migrate these websites in-house so they are aligned with our other static websites that get deployed through Jenkins automatically. There should be no impact for developers/users and it frees us to enable HTTPS on them later.
