### PR TITLE
Update job dependencies to 0.10.45.

### DIFF
--- a/jenkins_jobs/docker-gpii-first-discovery-server.yml
+++ b/jenkins_jobs/docker-gpii-first-discovery-server.yml
@@ -32,7 +32,7 @@
     git_app_branch: master
     git_docker_repo: https://github.com/GPII/first-discovery-server
     git_docker_branch: master
-    nodejs_version: 4.4.1
+    nodejs_version: 4.4.4
     docker_username: gpii
     docker_image: first-discovery-server
     docker_tag: latest
@@ -45,7 +45,7 @@
     jenkins_tag: master
     git_app_branch: master
     git_docker_branch: master
-    nodejs_version: 0.10.43
+    nodejs_version: 0.10.45
     docker_tag: latest
     jobs:
       - 'docker-gpii-first-discovery-server-all'

--- a/jenkins_jobs/docker-gpii-flow-manager.yml
+++ b/jenkins_jobs/docker-gpii-flow-manager.yml
@@ -36,7 +36,7 @@
     git_app_branch: master
     git_docker_repo: https://github.com/gpii-ops/docker-flow-manager
     git_docker_branch: master
-    nodejs_version: 0.10.43
+    nodejs_version: 0.10.45
     docker_username: gpii
     docker_image: flow-manager
     docker_tag: latest
@@ -49,7 +49,7 @@
     jenkins_tag: master
     git_app_branch: master
     git_docker_branch: master
-    nodejs_version: 0.10.43
+    nodejs_version: 0.10.45
     docker_tag: latest
     jobs:
       - 'docker-gpii-flow-manager-all'
@@ -65,7 +65,7 @@
     git_docker_repo: https://github.com/gpii-ops/docker-flow-manager
     git_app_branch: GPII-1245
     git_docker_branch: GPII-1245
-    nodejs_version: 0.10.43
+    nodejs_version: 0.10.45
     docker_tag: GPII-1245
     jobs:
       - 'docker-gpii-flow-manager-all'

--- a/jenkins_jobs/docker-gpii-preferences-server-data-loader.yml
+++ b/jenkins_jobs/docker-gpii-preferences-server-data-loader.yml
@@ -36,7 +36,7 @@
     git_app_branch: master
     git_docker_repo: https://github.com/gpii-ops/docker-preferences-server-data-loader.git
     git_docker_branch: master
-    nodejs_version: 0.10.43
+    nodejs_version: 0.10.45
     docker_username: gpii
     docker_image: preferences-server-data-loader
     docker_tag: latest
@@ -49,7 +49,7 @@
     jenkins_tag: review4
     git_app_branch: review4
     git_docker_branch: review4
-    nodejs_version: 0.10.43
+    nodejs_version: 0.10.45
     docker_tag: review4
     jobs:
       - 'docker-gpii-preferences-server-data-loader-all'
@@ -59,7 +59,7 @@
     jenkins_tag: master
     git_app_branch: master
     git_docker_branch: master
-    nodejs_version: 0.10.43
+    nodejs_version: 0.10.45
     docker_tag: latest
     jobs:
       - 'docker-gpii-preferences-server-data-loader-all'

--- a/jenkins_jobs/docker-gpii-preferences-server.yml
+++ b/jenkins_jobs/docker-gpii-preferences-server.yml
@@ -36,7 +36,7 @@
     git_app_branch: master
     git_docker_repo: https://github.com/gpii-ops/docker-preferences-server.git
     git_docker_branch: master
-    nodejs_version: 0.10.43
+    nodejs_version: 0.10.45
     docker_username: gpii
     docker_image: preferences-server
     docker_tag: latest
@@ -49,7 +49,7 @@
     jenkins_tag: review4
     git_app_branch: review4
     git_docker_branch: review4
-    nodejs_version: 0.10.43
+    nodejs_version: 0.10.45
     docker_tag: review4
     jobs:
       - 'docker-gpii-preferences-server-all'
@@ -59,7 +59,7 @@
     jenkins_tag: master
     git_app_branch: master
     git_docker_branch: master
-    nodejs_version: 0.10.43
+    nodejs_version: 0.10.45
     docker_tag: latest
     jobs:
       - 'docker-gpii-preferences-server-all'

--- a/jenkins_jobs/docker-gpii-universal.yml
+++ b/jenkins_jobs/docker-gpii-universal.yml
@@ -36,7 +36,7 @@
     git_app_branch: master
     git_docker_repo: https://github.com/GPII/universal.git
     git_docker_branch: master
-    nodejs_version: 0.10.43
+    nodejs_version: 0.10.45
     docker_username: gpii
     docker_image: universal
     docker_tag: latest
@@ -44,25 +44,12 @@
     email_recipient: ops-notifications@lists.inclusivedesign.ca
     jenkins_node: i-0027.tor1.inclusivedesign.ca
 
-# This was not needed for review4, so commenting out for now. 
-# It should be removed after the review if it's not used.
-#
-#- project:
-#    name: gpii-universal-review4
-#    jenkins_tag: review4
-#    git_app_branch: review4
-#    git_docker_branch: review4
-#    nodejs_version: 0.10.41
-#    docker_tag: review4
-#    jobs:
-#      - 'docker-gpii-universal-all'
-
 - project:
     name: gpii-universal-master
     jenkins_tag: master
     git_app_branch: master
     git_docker_branch: master
-    nodejs_version: 0.10.43
+    nodejs_version: 0.10.45
     docker_tag: latest
     jobs:
       - 'docker-gpii-universal-all'
@@ -78,7 +65,7 @@
     git_app_branch: GPII-1245
     git_docker_repo: https://github.com/cindyli/universal.git
     git_docker_branch: GPII-1245
-    nodejs_version: 0.10.43
+    nodejs_version: 0.10.45
     docker_tag: GPII-1245
     jobs:
       - 'docker-gpii-universal-all'


### PR DESCRIPTION
GPII/universal still has to be updated to use 0.10.45 because we're pinning the version there.

This just updates what the Jenkins watch for new builds (triggers).
