### PR TITLE
Cleanup Node.js versions (keep only latest of each branch)

### DIFF
--- a/jenkins_jobs/docker-idi-nodejs.yml
+++ b/jenkins_jobs/docker-idi-nodejs.yml
@@ -3,7 +3,7 @@
 - defaults:
     name: idi-nodejs
     git_repo: https://github.com/idi-ops/docker-nodejs.git
-    git_branch: 4.4.4
+    git_branch: lts
     docker_username: inclusivedesign
     docker_image: nodejs
     docker_tag: latest
@@ -14,32 +14,24 @@
 - project:
     name: idi-nodejs-latest
     jenkins_tag: latest
-    git_branch: 4.4.4
+    git_branch: lts
     docker_tag: latest
     jobs:
       - 'docker-idi-nodejs-all'
 
 - project:
-    name: idi-nodejs-0.10.45
-    jenkins_tag: 0.10.45
-    git_branch: 0.10.45
-    docker_tag: 0.10.45
+    name: idi-nodejs-lts
+    jenkins_tag: lts
+    git_branch: lts
+    docker_tag: lts
     jobs:
       - 'docker-idi-nodejs-all'
 
 - project:
-    name: idi-nodejs-4.4.4
-    jenkins_tag: 4.4.4
-    git_branch: 4.4.4
-    docker_tag: 4.4.4
-    jobs:
-      - 'docker-idi-nodejs-all'
-
-- project:
-    name: idi-nodejs-6.1.0
-    jenkins_tag: 6.1.0
-    git_branch: 6.1.0
-    docker_tag: 6.1.0
+    name: idi-nodejs-current
+    jenkins_tag: current
+    git_branch: current
+    docker_tag: current
     jobs:
       - 'docker-idi-nodejs-all'
 


### PR DESCRIPTION
I would like to take a hard stance regarding security fixes and let things break if they're known to be vulnerable to critical security bugs.

The only dependency I know we have is GPII/universal which stills has Node.js pinned. I have submitted GPII/universal#447 to update that and, as soon as the giant PR gets merged, we can submit another PR to have it target 'latest' instead (the LTS branch).

If anything else out there breaks, someone is overseeing security updates and it's a good opportunity to improve processes.
