### PR TITLE
Add SJRK Story Telling Server jobs

### DIFF
--- a/jenkins_jobs/stack-karisma-stories.floeproject.org.yml
+++ b/jenkins_jobs/stack-karisma-stories.floeproject.org.yml
@@ -1,0 +1,36 @@
+- job:
+    node: i-0033.tor1.inclusivedesign.ca
+    name: stack-karisma-stories.floeproject.org
+    project-type: freestyle
+    display-name: stack-karisma-stories.floeproject.org
+    scm:
+        - git:
+            url: https://github.com/waharnum/sjrk-story-telling-server.git
+            skip-tag: true
+            branches:
+                - SJRK-56-karisma
+    triggers:
+        - github
+        - reverse:
+            jobs: stack-stories.floeproject.org-nightly-cleanup
+            result: success
+    properties:
+      - inject:
+          properties-content: |
+            PROJECT_ID=c00c43b6
+            PROJECT_HOME=/srv/$PROJECT_ID
+            APP_SERVER_PORT=38087
+            APP_SERVER_SECRETS_FILE=$PROJECT_HOME/secrets.json
+            APP_SERVER_UPLOADS_DIRECTORY=$PROJECT_HOME/uploads
+            COUCHDB_DATADIR=$PROJECT_HOME/couchdb
+    builders:
+        - shell: |
+            #!/bin/sh -ex
+            /usr/local/bin/docker-compose -p "$PROJECT_ID" -f docker-compose.yml -f docker-compose.cloud.yml up --force-recreate --build -d
+
+            # Health check
+            /usr/bin/sleep 45
+            /usr/bin/curl --no-buffer --retry 120 --retry-delay 1 "https://karisma-stories.floeproject.org/stories"
+    publishers:
+      - email:
+            recipients: builds@lists.idrc.ocad.ca

--- a/jenkins_jobs/stack-stories.floeproject.org-nightly-cleanup.yml
+++ b/jenkins_jobs/stack-stories.floeproject.org-nightly-cleanup.yml
@@ -1,0 +1,19 @@
+- job:
+    node: i-0033.tor1.inclusivedesign.ca
+    name: stack-stories.floeproject.org-nightly-cleanup
+    project-type: freestyle
+    display-name: stack-stories.floeproject.org-nightly-cleanup
+    triggers:
+        - timed: "@midnight"
+    properties:
+      - inject:
+          properties-content: |
+            PROJECT_ID=f92c97d2
+            PROJECT_HOME=/srv/$PROJECT_ID
+    builders:
+        - shell: |
+            #!/bin/sh -ex
+            sudo rm -rf "$PROJECT_HOME/couchdb"
+    publishers:
+      - email:
+            recipients: builds@lists.idrc.ocad.ca

--- a/jenkins_jobs/stack-stories.floeproject.org.yml
+++ b/jenkins_jobs/stack-stories.floeproject.org.yml
@@ -1,0 +1,36 @@
+- job:
+    node: i-0033.tor1.inclusivedesign.ca
+    name: stack-stories.floeproject.org
+    project-type: freestyle
+    display-name: stack-stories.floeproject.org
+    scm:
+        - git:
+            url: https://github.com/waharnum/sjrk-story-telling-server.git
+            skip-tag: true
+            branches:
+                - SJRK-56-learningReflections
+    triggers:
+        - github
+        - reverse:
+            jobs: stack-stories.floeproject.org-nightly-cleanup
+            result: success
+    properties:
+      - inject:
+          properties-content: |
+            PROJECT_ID=f92c97d2
+            PROJECT_HOME=/srv/$PROJECT_ID
+            APP_SERVER_PORT=38086
+            APP_SERVER_UPLOADS_DIRECTORY=$PROJECT_HOME/uploads
+            APP_SERVER_SECRETS_FILE=$PROJECT_HOME/secrets.json
+            COUCHDB_DATADIR=$PROJECT_HOME/couchdb
+    builders:
+        - shell: |
+            #!/bin/sh -ex
+            /usr/local/bin/docker-compose -p "$PROJECT_ID" -f docker-compose.yml -f docker-compose.cloud.yml up --force-recreate --build -d
+
+            # Health check
+            /usr/bin/sleep 45
+            /usr/bin/curl --no-buffer --retry 120 --retry-delay 1 "https://stories.floeproject.org/stories"
+    publishers:
+      - email:
+            recipients: builds@lists.idrc.ocad.ca


### PR DESCRIPTION
Two jobs, one for each app.

A third job that gets triggered at midnight to cleanup the database and trigger a new build.