### PR TITLE
Remove old unused files

### DIFF
--- a/jenkins_jobs/website-sojustrepairit.org.yml
+++ b/jenkins_jobs/website-sojustrepairit.org.yml
@@ -17,6 +17,7 @@
             site: 'e7b4f940_sojustrepairit.org'
             source: '**'
             target: '/var/www/e7b4f940'
+            clean-remote: true
             fail-on-error: true
             use-pty: true
             timeout: 180000


### PR DESCRIPTION
@waharnum I'm trying this change because I'm seeing odd behaviour with the published site. Even though the [project repository](https://github.com/fluid-project/sojustrepairit.org) doesn't contain an ``activity.html`` file the https://sojustrepairit.org/activity.html link points clients to the files left over from previous deployments. 