### PR TITLE
SJRK-224: updating Production Storytelling job to point to combined repo

### DIFF
--- a/jenkins_jobs/stack-stories.floeproject.org.yml
+++ b/jenkins_jobs/stack-stories.floeproject.org.yml
@@ -5,7 +5,7 @@
     display-name: stack-stories.floeproject.org
     scm:
         - git:
-            url: https://github.com/fluid-project/sjrk-story-telling-server.git
+            url: https://github.com/fluid-project/sjrk-story-telling.git
             skip-tag: true
             branches:
                 - stories-floe-production


### PR DESCRIPTION
Same as last time, except the production site job.

This should only be merged in once the Storytelling Tool [dev branch](https://github.com/fluid-project/sjrk-story-telling/tree/stories-floe-dev) has been merged into the [production branch](https://github.com/fluid-project/sjrk-story-telling/tree/stories-floe-production)