### PR TITLE
SJRK-268: added backup job for Cities Stories site

### DIFF
--- a/jenkins_jobs/stack-stories.cities.inclusivedesign.ca-backup.yml
+++ b/jenkins_jobs/stack-stories.cities.inclusivedesign.ca-backup.yml
@@ -1,0 +1,17 @@
+- job:
+    node: i-0033.tor1.incd.ca
+    name: stack-stories.cities.inclusivedesign.ca-backup
+    project-type: freestyle
+    display-name: stack-stories.cities.inclusivedesign.ca-backup
+    properties:
+      - inject:
+          properties-content: |
+            PROJECT_ID=6d4309f7
+            PROJECTS_DIRECTORY=/srv
+    builders:
+        - shell: |
+            #!/bin/sh -ex
+            sudo /srv/backup.sh $PROJECT_ID $PROJECTS_DIRECTORY
+    publishers:
+      - email:
+            recipients: ops-notifications@lists.inclusivedesign.ca


### PR DESCRIPTION
Added a job to handle automatic backup for [Cities Storytelling Tool](https://stories.cities.inclusivedesign.ca/)