### PR TITLE
SJRK-321: "migrating" staging site from `stories-floe-dev` to `master`

### DIFF
--- a/jenkins_jobs/stack-staging-stories.floeproject.org.yml
+++ b/jenkins_jobs/stack-staging-stories.floeproject.org.yml
@@ -8,7 +8,7 @@
             url: https://github.com/fluid-project/sjrk-story-telling.git
             skip-tag: true
             branches:
-                - stories-floe-dev
+                - master
     triggers:
         - github
         - reverse:


### PR DESCRIPTION
This pull request coincides with another pull request to update the Storytelling Tool code to satisfy the Laser Eye Checklist: fluid-project/sjrk-story-telling/pull/58