### PR TITLE
FLUID-6324: Update docpad genertion to use locally installed docpad

### DIFF
--- a/jenkins_jobs/website-fluidproject.org.yml
+++ b/jenkins_jobs/website-fluidproject.org.yml
@@ -14,8 +14,7 @@
         - shell: |
             #!/bin/sh -ex
             npm install
-            npm install docpad
-            $(npm bin)/docpad generate --env static
+            npm run generate
     publishers:
       - email:
             recipients: ops-notifications@lists.inclusivedesign.ca


### PR DESCRIPTION
Updating CI scripts to use the updated method for generating a docpad build for a locally installed docpad.

Resolves https://github.com/inclusive-design/ci-service/issues/38